### PR TITLE
Room with flow

### DIFF
--- a/app/src/main/java/com/thingsflow/internapplication/data/GithubRepoDao.kt
+++ b/app/src/main/java/com/thingsflow/internapplication/data/GithubRepoDao.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface GithubRepoDao {
     @Insert(onConflict = REPLACE)
-    fun insert(githubRepo: GithubRepo)
+    suspend fun insert(githubRepo: GithubRepo)
 
     @Query("SELECT * FROM github_repo WHERE org_name = :orgName and repo_name = :repoName")
-    fun getGithubRepoByOrgAndRepo(orgName: String, repoName: String) : GithubRepo
+    fun getGithubRepoByOrgAndRepo(orgName: String, repoName: String) : Flow<GithubRepo>
 }

--- a/app/src/main/java/com/thingsflow/internapplication/ui/main/MainRepository.kt
+++ b/app/src/main/java/com/thingsflow/internapplication/ui/main/MainRepository.kt
@@ -25,15 +25,11 @@ class MainRepository @Inject constructor(
         }
     }
 
-    fun getIssuesRoom(org: String, repo: String) : Flow<List<Item.Issue>?>  {
-        return flow {
-            val githubRepo = githubRepoDatabase.githubRepoDao().getGithubRepoByOrgAndRepo(org, repo)
-            if (githubRepo != null) emit(githubRepo.issueList)
-            else emit(null)
-        }
+    fun getIssuesRoom(org: String, repo: String) : Flow<GithubRepo?>  {
+        return githubRepoDatabase.githubRepoDao().getGithubRepoByOrgAndRepo(org, repo)
     }
 
-    fun insertGithubRepoToRoom(org: String, repo: String, issueList: List<Item.Issue>) {
+    suspend fun insertGithubRepoToRoom(org: String, repo: String, issueList: List<Item.Issue>) {
         githubRepoDatabase.githubRepoDao().insert(GithubRepo(org, repo, issueList))
     }
 }


### PR DESCRIPTION
Room을 flow와 결합하여 네트워크에서 처음 가져온 데이터를 viewModel의 데이터에 바로 넣지 않고, 대신 room에 넣은 후, flow를 통해 자동으로 room에 들어간 데이터를 가져와 viewModel의 데이터에 넣어주는 방식을 구현했습니다.
그런데 문제가 하나 발생하고 있는데 아직 해결하지 못하였습니다 ㅠㅠ
어떤 org/repo를 처음 검색하면, 네트워크에서 데이터를 가져와서 room에 insert를 하는데요, insert가 발생하면 
mainRepository.getIssuesRoom(orgName, repoName).collect {
...
}
이 collect 내부의 코드가 이전에 검색한 내역의 orgName, repoName에 대해 모두 호출됩니다. 그리고 이 호출의 순서가 무슨 기준으로 되는진 모르겠지만 방금 insert한 데이터가 맨 마지막에 호출되는게 보장되지 않아서 검색한 레포지토리가 잠깐 떴다가 이전에 검색했던 레포지토리에 대해 코드가 다시 실행되어 마지막으로 호출된 레포지토리의 내용이 최종적으로 적용되게 됩니다.
예를 들어 google/dagger를 두번 검색하고, flutter/flutter를 한번 검색하고 square/retrofit을 검색했다고 하면, 저는 retrofit의 결과를 원하는데, square/retrofit 데이터를 Insert한 후, collect 함수가
flutter/flutter
square/retrofit
google/dagger
google/dagger
이 순서로 불려지게 되어 retrofit의 내용이 잠깐 떴다가 google/dagger의 결과가 최종적으로 나타나게 되네요 ㅠㅠ

뭔가 flow를 잘못 적용해서 문제가 발생하고 있는 듯 한데, 아직 해결법을 찾지 못해서 혹시 힌트를 조금 주시면 감사하겠습니다..!